### PR TITLE
Use exec form of entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,4 @@ RUN luarocks install luasocket
 VOLUME /root/.piecestopractice
 COPY . /ptp
 WORKDIR /ptp
-EXPOSE 80
-ENTRYPOINT ./ws.lua
+ENTRYPOINT ["./ws.lua"]


### PR DESCRIPTION
@Ocawesome101 This switches the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint) line to use the exec form.

> Command line arguments to docker run <image> will be appended after all elements in an exec form `ENTRYPOINT` ... The shell form prevents any `CMD` or `run` command line arguments from being used ...

This change makes it so that the [start script](https://github.com/spraints/tiny/blob/278092ae1e27c71e0dac4d78c4f37599102d2cfa/ptp/start#L24-L25) can simply pass 8888, rather than overriding the entrypoint in order to pass the arg.